### PR TITLE
Adds `make run-wazero`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,16 @@ serve:
 run-wasmtime:
 	wasmtime run opt/wasi-python/bin/python3.wasm --mapdir /::./ --env 'PYTHONHOME=/opt/wasi-python/lib/python3.11' --env 'PYTHONPATH=/opt/wasi-python/lib/python3.11' -- code/env.py
 
+# Until 1.0, install via: go install github.com/tetratelabs/wazero/cmd/wazero@latest
+#
+# Notes:
+#
+# * add `-hostlogging=filesystem` to see how WASI behaves underneath.
+# * add `-cachedir=$HOME/.wazero` to reduce time running python the second time.
+.PHONY: run-wazero
+run-wazero:
+	wazero run -mount=.:/ -env=PYTHONHOME=/opt/wasi-python/lib/python3.11 -env=PYTHONPATH=/opt/wasi-python/lib/python3.11  opt/wasi-python/bin/python3.wasm -- code/env.py
+
 .PHONY: tail-logs
 tail-logs:
 	tail -f ${LOGDIR}/*/*


### PR DESCRIPTION
This adds a command to run this example with wazero, as someone tried before and failed.

```bash
$ make run-wazero
wazero run -mount=.:/ -env=PYTHONHOME=/opt/wasi-python/lib/python3.11 -env=PYTHONPATH=/opt/wasi-python/lib/python3.11  opt/wasi-python/bin/python3.wasm -- code/env.py
Content-Type: text/plain; charset=UTF-8
Status: 200

Hello from python on wasi

### Arguments ###

['code/env.py']

### Env Vars ###

PYTHONHOME: /opt/wasi-python/lib/python3.11
PYTHONPATH: /opt/wasi-python/lib/python3.11

### Files ###

env.py
//code/env.py:31: DeprecationWarning: The 'warn' function is deprecated, use 'warning' instead
  logging.warn('Logging important warnings')
WARNING:root:Logging important warnings
```

Fixes tetratelabs/wazero#769
